### PR TITLE
Add 'v' to version number of circleci config

### DIFF
--- a/config/circleci.json
+++ b/config/circleci.json
@@ -18,5 +18,5 @@
       "value": "a8654152-74c0-41dd-a954-bcab50ff99d4"
     }
   },
-  "version": "1.0"
+  "version": "v1.0"
 }


### PR DESCRIPTION
r? @albertopq 

I missed this on https://github.com/mozilla-sensorweb/sensorweb-server/commit/8379dcc6f77834dd80dddf37c6b87da06e665424