### PR TITLE
Update Babel configuration to run only the necessary transformations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,10 @@
 {
-  "presets": [ "es2015" ],
+  "presets": [["env", {
+    "targets": {
+      "node": "current"
+    }
+  }]],
   "ignore": [
-    "*.swp"
+    "*.sw?"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "license": "MPL-2.0",
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.16.3",
+    "babel-cli": "^6.18.0",
+    "babel-preset-env": "^1.1.8",
+    "babel-register": "^6.18.0",
     "coveralls": "^2.11.14",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",


### PR DESCRIPTION
This change makes babel configuration dependant on the node version we use. With node 6 it will only transform ES6 modules to CommonJS modules, because node 6 supports mostly all of modern JavaScript.

Using the `env` presets makes it very easy to upgrade later and use some new stuff even if Node doesn't support it yet.